### PR TITLE
Align legend wording with custom-select dropdown

### DIFF
--- a/froide_govplan/locale/de/LC_MESSAGES/django.po
+++ b/froide_govplan/locale/de/LC_MESSAGES/django.po
@@ -223,7 +223,7 @@ msgstr "umgesetzt"
 
 #: froide_govplan/models.py:38
 msgid "deferred"
-msgstr "verschoben"
+msgstr "zurückgestellt"
 
 #: froide_govplan/models.py:51
 msgid "terrible"

--- a/froide_govplan/templates/froide_govplan/section.html
+++ b/froide_govplan/templates/froide_govplan/section.html
@@ -49,7 +49,7 @@
             <span class="text-nowrap mr-1"><i class="fa fa-circle text-primary"></i>&nbsp;begonnen</span>
             <span class="text-nowrap mr-1"><i class="fa fa-circle text-warning"></i>&nbsp;teilweise umgesetzt</span>
             <span class="text-nowrap mr-1"><i class="fa fa-circle text-success"></i>&nbsp;umgesetzt</span>
-            <span class="text-nowrap mr-1"><i class="fa fa-circle text-danger"></i>&nbsp;verschoben</span>
+            <span class="text-nowrap mr-1"><i class="fa fa-circle text-danger"></i>&nbsp;zurückgestellt</span>
           </p>          
         </div>
       </div>


### PR DESCRIPTION
This harmonizes this currently diverging wording:

![image](https://user-images.githubusercontent.com/9948149/177257577-447cdaff-85ed-49ef-9e24-ab413b16f3c3.png)

Couldn't find the source for `zurückgestellt` in `custom-select` (An  external dataset, maybe?), so I went this way. I'd be happy to switch it around if you let me know where.