### PR TITLE
Add missing oauth2_provider app

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -62,6 +62,7 @@ INSTALLED_APPS = [
     "treebeard",
     "taggit",
     "tinymce",
+    'oauth2_provider',
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
Otherwise froide-govplan fails to start with:

```
[...]
Nov 27 11:50:39 nixos froide-govplan[904]:   File "/nix/store/93045iaxq4w0pl97zi92sm68i8bc1ngl-python3.12-django-4.2.16/lib/python3.12/site-packages/django/core/management/commands/runserver.py", line 125, in inner_run
Nov 27 11:50:39 nixos froide-govplan[904]:     autoreload.raise_last_exception()
Nov 27 11:50:39 nixos froide-govplan[904]:   File "/nix/store/93045iaxq4w0pl97zi92sm68i8bc1ngl-python3.12-django-4.2.16/lib/python3.12/site-packages/django/utils/autoreload.py", line 87, in raise_last_exception
Nov 27 11:50:39 nixos froide-govplan[904]:     raise _exception[1]
Nov 27 11:50:39 nixos froide-govplan[904]:   File "/nix/store/93045iaxq4w0pl97zi92sm68i8bc1ngl-python3.12-django-4.2.16/lib/python3.12/site-packages/django/core/management/__init__.py", line 394, in execute
Nov 27 11:50:39 nixos froide-govplan[904]:     autoreload.check_errors(django.setup)()
Nov 27 11:50:39 nixos froide-govplan[904]:   File "/nix/store/93045iaxq4w0pl97zi92sm68i8bc1ngl-python3.12-django-4.2.16/lib/python3.12/site-packages/django/utils/autoreload.py", line 64, in wrapper
Nov 27 11:50:39 nixos froide-govplan[904]:     fn(*args, **kwargs)
Nov 27 11:50:39 nixos froide-govplan[904]:   File "/nix/store/93045iaxq4w0pl97zi92sm68i8bc1ngl-python3.12-django-4.2.16/lib/python3.12/site-packages/django/__init__.py", line 24, in setup
Nov 27 11:50:39 nixos froide-govplan[904]:     apps.populate(settings.INSTALLED_APPS)
Nov 27 11:50:39 nixos froide-govplan[904]:   File "/nix/store/93045iaxq4w0pl97zi92sm68i8bc1ngl-python3.12-django-4.2.16/lib/python3.12/site-packages/django/apps/registry.py", line 124, in populate
Nov 27 11:50:39 nixos froide-govplan[904]:     app_config.ready()
Nov 27 11:50:39 nixos froide-govplan[904]:   File "/nix/store/9rshwj3aqgp8012gdcakk7k1fd20zqfw-froide-0-unstable-2024-11-13/lib/python3.12/site-packages/froide/publicbody/apps.py", line 12, in ready
Nov 27 11:50:39 nixos froide-govplan[904]:     from froide.account.export import registry
Nov 27 11:50:39 nixos froide-govplan[904]:   File "/nix/store/9rshwj3aqgp8012gdcakk7k1fd20zqfw-froide-0-unstable-2024-11-13/lib/python3.12/site-packages/froide/account/export.py", line 19, in <module>
Nov 27 11:50:39 nixos froide-govplan[904]:     from .tasks import start_export_task
Nov 27 11:50:39 nixos froide-govplan[904]:   File "/nix/store/9rshwj3aqgp8012gdcakk7k1fd20zqfw-froide-0-unstable-2024-11-13/lib/python3.12/site-packages/froide/account/tasks.py", line 8, in <module>
Nov 27 11:50:39 nixos froide-govplan[904]:     from oauth2_provider.models import clear_expired as clear_expired_oauth2_tokens
Nov 27 11:50:39 nixos froide-govplan[904]:   File "/nix/store/i5kzhk8s8h0c4pzsdssig3qh41hrx1gp-python3.12-django-oauth-toolkit-3.0.1/lib/python3.12/site-packages/oauth2_provider/models.py", line 284, in <module>
Nov 27 11:50:39 nixos froide-govplan[904]:     class Application(AbstractApplication):
Nov 27 11:50:39 nixos froide-govplan[904]:   File "/nix/store/93045iaxq4w0pl97zi92sm68i8bc1ngl-python3.12-django-4.2.16/lib/python3.12/site-packages/django/db/models/base.py", line 134, in __new__
Nov 27 11:50:39 nixos froide-govplan[904]:     raise RuntimeError(
Nov 27 11:50:39 nixos froide-govplan[904]: RuntimeError: Model class oauth2_provider.models.Application doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS.
```