### PR TITLE
Enable automatic image cropping for filer

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -198,6 +198,13 @@ FROIDE_CONFIG = {
 ELASTICSEARCH_INDEX_PREFIX = "govplan"
 CMS_CONFIRM_VERSION4 = True
 
+THUMBNAIL_PROCESSORS = (
+    'easy_thumbnails.processors.colorspace',
+    'easy_thumbnails.processors.autocrop',
+    'filer.thumbnail_processors.scale_and_crop_with_subject_location',
+    'easy_thumbnails.processors.filters',
+)
+
 # Govplan settings
 
 GOVPLAN_NAME = "GovPlan"


### PR DESCRIPTION
Enable automatic image cropping for "filer" thumbnails, otherwise rendering the section template will fail